### PR TITLE
Fixed iOS createConfig to read from secure storage if the refresh token has not expired rather than the access token

### DIFF
--- a/ios/Classes/SwiftFlutterOktaSdkPlugin.swift
+++ b/ios/Classes/SwiftFlutterOktaSdkPlugin.swift
@@ -205,7 +205,7 @@ public class SwiftFlutterOktaSdkPlugin: NSObject, FlutterPlugin {
       callback(error);
     }
     if let oktaOidc = oktaOidc,
-         let _ = OktaOidcStateManager.readFromSecureStorage(for: oktaOidc.configuration)?.accessToken {
+         let _ = OktaOidcStateManager.readFromSecureStorage(for: oktaOidc.configuration)?.refreshToken {
         self.stateManager = OktaOidcStateManager.readFromSecureStorage(for: oktaOidc.configuration)
       }
       callback(nil)


### PR DESCRIPTION
https://github.com/sonikro/flutter-okta-sdk/issues/20

Before, `refreshTokens()` would not work after restarting iOS app because app never reads from secure storage if access token had expired.  For mobile apps, it's preferred to keep the user signed in as long as they have a non-expired refresh token.  

Question: will these changes be present after running `flutter pub get` after I merge to the `develop` branch, or do we need to modify the version number as well?

